### PR TITLE
Get Horace-Euphonic-Interface from GitHub artifact

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
 
   environment {
     MATLAB_VERSION = utilities.get_param('MATLAB_VERSION', pli.matlab_release.replace('R', ''))
-    CONDA_ENV_NAME = "py36_pace_integration_${env.MATLAB_VERSION}"
+    CONDA_ENV_NAME = "py37_pace_integration_${env.MATLAB_VERSION}"
     HORACE_BRANCH = utilities.get_param('HORACE_BRANCH', 'master')
     EUPHONIC_BRANCH = utilities.get_param('EUPHONIC_BRANCH', 'master')
     HORACE_EUPHONIC_INTERFACE_BRANCH = utilities.get_param('HORACE_EUPHONIC_INTERFACE_BRANCH', 'master')
@@ -201,7 +201,7 @@ pipeline {
           if (isUnix()) {
             sh '''
               module load conda/3 &&
-              conda create --name \$CONDA_ENV_NAME python=3.6 -y
+              conda create --name \$CONDA_ENV_NAME python=3.7 -y
             '''
           }
           else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,7 +147,7 @@ pipeline {
             '''
           }
           else {
-            powershell './powershell_scripts/extract_horace_artifact.ps1'
+            powershell './powershell_scripts/extract_artifact.ps1 "build/Horace-*.zip" "Horace"'
           }
 
         }
@@ -158,9 +158,17 @@ pipeline {
       steps {
         script {
           def artifact_url = get_artifact_url(env.HORACE_EUPHONIC_INTERFACE_BRANCH)
-          httpRequest httpMode: 'GET',
-                      url: '${artifact_url}',
-                      authenticatrion: 'GitHub_API_Token'
+          def response = httpRequest httpMode: 'GET',
+                                     url: '${artifact_url}',
+                                     authentication: 'GitHub_API_Token',
+                                     outputFile: 'out.zip'
+          println("Status: " + response.status)
+          if (isUnix()) {
+            sh 'unzip out.zip'
+          }
+          else {
+            powershell './powershell_scripts/extract_artifact.ps1 "out.zip" "horace_euphonic_interface.mltbx"'
+          }
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,6 +97,7 @@ pipeline {
   environment {
     MATLAB_VERSION = utilities.get_param('MATLAB_VERSION', pli.matlab_release.replace('R', ''))
     CONDA_ENV_NAME = "py37_pace_integration_${env.MATLAB_VERSION}"
+    CONDA_PY_VERSION = "3.7"
     HORACE_BRANCH = utilities.get_param('HORACE_BRANCH', 'master')
     EUPHONIC_BRANCH = utilities.get_param('EUPHONIC_BRANCH', 'master')
     HORACE_EUPHONIC_INTERFACE_BRANCH = utilities.get_param('HORACE_EUPHONIC_INTERFACE_BRANCH', 'master')
@@ -112,7 +113,7 @@ pipeline {
         dir('PACE-jenkins-shared-library') {
           checkout([
             $class: 'GitSCM',
-            branches: [[name: "refs/heads/main"]],
+            branches: [[name: "refs/heads/py_version_env"]],
             extensions: [[$class: 'WipeWorkspace']],
             userRemoteConfigs: [[url: 'https://github.com/pace-neutrons/PACE-jenkins-shared-library.git']]
           ])
@@ -199,10 +200,10 @@ pipeline {
       steps {
         script {
           if (isUnix()) {
-            sh '''
+            sh """
               module load conda/3 &&
-              conda create --name \$CONDA_ENV_NAME python=3.7 -y
-            '''
+              conda create --name \$CONDA_ENV_NAME python=\$CONDA_PY_VERSION -y
+            """
           }
           else {
             powershell './PACE-jenkins-shared-library/powershell_scripts/create_conda_environment.ps1'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,7 +113,7 @@ pipeline {
         dir('PACE-jenkins-shared-library') {
           checkout([
             $class: 'GitSCM',
-            branches: [[name: "refs/heads/py_version_env"]],
+            branches: [[name: "refs/heads/main"]],
             extensions: [[$class: 'WipeWorkspace']],
             userRemoteConfigs: [[url: 'https://github.com/pace-neutrons/PACE-jenkins-shared-library.git']]
           ])

--- a/get_artifact_url.py
+++ b/get_artifact_url.py
@@ -1,0 +1,78 @@
+#! /usr/bin/env python3
+
+from argparse import ArgumentParser
+from typing import Optional
+import requests
+import json
+import os
+
+def main():
+    """
+    Given a branch of the Horace-Euphonic-Interface repo,
+    prints the latest artifact url
+    """
+    parser = ArgumentParser()
+    parser.add_argument('branch', type=str,
+        help='Branch of repo to query')
+
+    args = parser.parse_args()
+    url = get_artifact_url(branch=args.branch)
+    print(url)
+
+def get_response_json(url):
+    response = requests.get(url)
+    response.raise_for_status()
+    return response.json()
+
+def get_artifact_url(repo: str = 'horace-euphonic-interface',
+                     branch: str = 'master',
+                     workflow_name: str = 'Horace-Euphonic-Interface Tests',
+                     artifact_name: str = 'horace_euphonic_interface.mltbx'):
+    """
+    For a specific pace-neutrons Github repository and branch, query
+    the workflows API to get the latest successful build, get the matching
+    build artifact and print the artifact download URL.
+    """
+    base_url = 'https://api.github.com'
+
+    # Get workflow ID
+    workflows_url = f'{base_url}/repos/pace-neutrons/{repo}/actions/workflows'
+    content = get_response_json(workflows_url)
+    workflow_id = None
+    for workflow in content['workflows']:
+        if workflow['name'] == workflow_name:
+            workflow_id = workflow['id']
+            break
+    if workflow_id is None:
+        raise RuntimeError(f'Workflow with name {workflow_name} '
+                           f'couldn\'t be found at {workflows_url}')
+  
+    # Get matching workflow run id
+    workflow_runs_url = f'{workflows_url}/{workflow_id}/runs'
+    content = get_response_json(workflow_runs_url)
+    workflow_run_id = None
+    for workflow_run in content['workflow_runs']:
+        if (workflow_run['status'] == 'completed' and
+                workflow_run['conclusion'] == 'success' and
+                workflow_run['head_branch'] == branch):
+            workflow_run_id = workflow_run['id']
+            break
+    if workflow_run_id is None:
+        raise RuntimeError(f'Successful workflow with branch {branch} '
+                           f'couldn\'t be found at {workflow_runs_url}')
+
+    # Get matching artifact
+    artifacts_url = (f'{base_url}/repos/pace-neutrons/{repo}/actions/'
+                    f'runs/{workflow_run_id}/artifacts')
+    content = get_response_json(artifacts_url)
+    artifact_download_url = None
+    for artifact in content['artifacts']:    
+        if artifact['name'] == artifact_name:
+            artifact_download_url = artifact['archive_download_url']
+    if artifact_download_url is None:
+        raise RuntimeError(f'Artifact with name {artifact_name} '
+                           f'couldn\'t be found at {artifacts_url}')
+    return artifact_download_url
+
+if __name__ == '__main__':
+    main()

--- a/iron_spinwaves/Jenkinsfile
+++ b/iron_spinwaves/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
             '''
           }
           else {
-            powershell './powershell_scripts/extract_horace_artifact.ps1'
+            powershell './powershell_scripts/extract_artifact.ps1 "build/Horace-*.zip" "Horace"'
           }
 
         }

--- a/powershell_scripts/extract_artifact.ps1
+++ b/powershell_scripts/extract_artifact.ps1
@@ -2,10 +2,23 @@
   Write-And-Invoke
 #>
 
+<#
+  .SYNOPSIS
+    Extracts a zip archive
+  .PARAMETER zipname
+    The file to unzip, may include globs
+  .PARAMETER newname
+    What to name the unzipped item
+  .EXAMPLE
+    extract_horace_artifact.ps1 "build/Horace-*.zip" "Horace"
+#>
+
 # Index "-1" here to deal with case where we may have more than one artifact.
 # We always want the last in the list, that will be the latest as they're
 # sorted alphabetically
-$zip_name_filter = "build/Horace-*.zip"
+$zip_name_filter = $args[0]
+$out_name = $args[1]
+
 try {
   $zip_file = (Get-Item "$zip_name_filter")[-1]
 } catch [System.Management.Automation.RuntimeException] {
@@ -13,7 +26,7 @@ try {
   exit 1;
 }
 
-# Extract Horace archive to user's temp directory
+# Extract the archive to user's temp directory
 # We extract to the temp directory instead of the current directory as the path
 # lengths can exceed the maximum allowed (255 characters) and the
 # "Expand-Archive" command does not offer a renaming utility
@@ -22,17 +35,18 @@ $extract_cmd = "Expand-Archive -Force -LiteralPath " + $zip_file.FullName
 $extract_cmd += " -DestinationPath $env:TEMP"
 Write-And-Invoke "$extract_cmd"
 
-# Make sure there's no Horace already in the working directory. PowerShell
-# will not overwrite directories - even with the "-Force" flag
-if (Test-Path "Horace") {
-  Write-Output "Removing existing Horace directory..."
-  Write-And-Invoke "Remove-Item -Force -Recurse -Path Horace"
+# Make sure there's no item already in the working directory with the
+# output name. PowerShell will not overwrite directories - even with
+# the "-Force" flag
+if (Test-Path $out_name) {
+  Write-Output "Removing existing  $out_name directory..."
+  Write-And-Invoke "Remove-Item -Force -Recurse -Path $out_name"
 }
 
-# Move the expanded archive to the current directory and rename to Horace
+# Move the expanded archive to the current directory and rename
 $extraction_path = [IO.Path]::Combine($env:TEMP, $zip_file.BaseName)
 Write-And-Invoke "Move-Item -Force -Path $extraction_path -Destination ."
-Write-And-Invoke "Rename-Item -Force -Path $($zip_file.BaseName) -NewName Horace"
+Write-And-Invoke "Rename-Item -Force -Path $($zip_file.BaseName) -NewName $out_name"
 try {
   Write-And-Invoke "Remove-Item -Force -Recurse -Path $extraction_path -ErrorAction Stop"
 } catch {

--- a/setup_and_run_tests.m
+++ b/setup_and_run_tests.m
@@ -27,7 +27,7 @@ for i = 1:length(toolboxes)
         break;
     end
 end
-matlab.addons.toolbox.installToolbox(['mltbx' filesep 'horace_euphonic_interface.mltbx']);
+matlab.addons.toolbox.installToolbox(['horace_euphonic_interface.mltbx']);
 matlab.addons.toolbox.installedToolboxes
 
 % Run tests


### PR DESCRIPTION
As a result of Horace-Euphonic-Interface moving to Github Actions (https://github.com/pace-neutrons/horace-euphonic-interface/pull/27), this requires some changes to get the `mltbx`. Main changes:

* Create `get_artifact_url.py` script to get the `horace_euphonic_interface.mltbx` URL using the Github API
* Update `extract_horace_artifact` script to be more generic so we can use it to extract the `mltbx` too (the URL provided by the Github API is always a .zip currently)
* Specify the Python version in an environment variable (Euphonic requirement has increased from 3.6 -> 3.7). Requires https://github.com/pace-neutrons/PACE-jenkins-shared-library/pull/3 to be merged.