### PR TITLE
Bugfixes to run integration tests again.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,9 +41,9 @@ def get_build_info(String repo, String branch, String match_context) {
   return [job_name, build_num]
 }
 
-def get_artifact_url(String branch) {
+def get_artifact_url(String branch, String api_token) {
   def artifact_url
-  def script_cmd = "python get_artifact_url.py ${branch}"
+  def script_cmd = "python get_artifact_url.py ${branch} --api-token ${api_token}"
   if (isUnix()) {
     artifact_url = sh(script: "module load conda/3 && ${script_cmd}", returnStdout: true)
   } else {
@@ -160,7 +160,7 @@ pipeline {
         script {
           withCredentials([string(credentialsId: 'GitHub_API_Token',
                                   variable: 'api_token')]) {
-            def artifact_url = get_artifact_url(env.HORACE_EUPHONIC_INTERFACE_BRANCH)
+            def artifact_url = get_artifact_url(env.HORACE_EUPHONIC_INTERFACE_BRANCH, api_token)
             if (isUnix()) {
               sh """
                 curl -LO -H "Authorization: token ${api_token}" --request GET ${artifact_url}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ def is_master_build(String build_type) {
 def get_readable_os(String os) {
   if (os == 'sl7') {
     return 'Scientific-Linux-7'
-  } else if (os == 'win10') {
+  } else if (os == 'win10' || os == 'pacewin') {
     return 'Windows-10'
   } else {
     return ''
@@ -230,8 +230,13 @@ pipeline {
             }
             else {
               bat """
-                CALL "%VS2019_VCVARSALL%" x86_amd64
-                CALL conda activate %CONDA_ENV_NAME%
+                set
+                echo %cd%
+                cd "%VS140COMNTOOLS%"
+                dir /s vcvar*
+                CALL "%VS140COMNTOOLS%vcvarsall.bat" x86_amd64
+                CALL conda.bat activate %CONDA_ENV_NAME%
+                where python
                 python -mpip install --upgrade pip
                 python -mpip install psutil
                 python -mpip install numpy

--- a/brille_spinwaves/Jenkinsfile
+++ b/brille_spinwaves/Jenkinsfile
@@ -99,9 +99,10 @@ pipeline {
           if (isUnix()) {
             sh '''
               module load conda/3 &&
-              conda create --name \$CONDA_ENV_NAME python=3.6 -y &&
+              conda create --name \$CONDA_ENV_NAME -c conda-forge python=3.8 -y &&
               conda activate \$CONDA_ENV_NAME &&
-              python -m pip install brille numpy requests &&
+              conda install -c conda-forge numpy gcc
+              python -m pip install brille requests &&
               python brille_spinwaves/get_brille_toolbox.py
             '''
           }

--- a/brille_spinwaves/Jenkinsfile
+++ b/brille_spinwaves/Jenkinsfile
@@ -99,7 +99,7 @@ pipeline {
           if (isUnix()) {
             sh '''
               module load conda/3 &&
-              conda create --name \$CONDA_ENV_NAME -c conda-forge python=3.8 -y &&
+              conda create --name \$CONDA_ENV_NAME -c conda-forge python=3.6 -y &&
               conda activate \$CONDA_ENV_NAME &&
               conda install -c conda-forge numpy gcc
               python -m pip install brille requests &&

--- a/brille_spinwaves/Jenkinsfile
+++ b/brille_spinwaves/Jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
               module load conda/3 &&
               conda create --name \$CONDA_ENV_NAME -c conda-forge python=3.6 -y &&
               conda activate \$CONDA_ENV_NAME &&
-              conda install -c conda-forge numpy gcc
+              conda install -c conda-forge numpy gxx
               python -m pip install brille requests &&
               python brille_spinwaves/get_brille_toolbox.py
             '''


### PR DESCRIPTION
* Change `brille` compilation to use `gcc-12` from `conda` as Brille needs a C++17 compiler and only `gcc-4` is installed on SL-7 nodes by default
* Change `get_artifact_url.py` to use the `GITHUB_API_TOKEN` to access Github as an authenticated user. Runs were failing because unauthenticated use of the Github API is rate limited to 60 requests per hour (authenticated use is 5000 per hour).
* Change Windows 10 builds to use the computing group provided VMs instead of our old Jenkins server